### PR TITLE
feat: define定義ファイル追加

### DIFF
--- a/EleCuit/Assets/mcs.rsp
+++ b/EleCuit/Assets/mcs.rsp
@@ -1,0 +1,3 @@
+
+-define:DU_DEBUG
+

--- a/EleCuit/Assets/mcs.rsp.meta
+++ b/EleCuit/Assets/mcs.rsp.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0833844906a594be9b46ecfd5a67f9fa
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
以下と対応している#define定義用ファイルを追加しました
https://github.com/directiveXgames/dUnitility/pull/8

Assets/直下に置かないとダメらしいのでClient差分として計上

なお、#defineを定義する方法が3つあるらしいです

1. mcs.rspに記述する方法 (採用)
2. csスクリプト内で`#define`する方法
3. UnityのPlayerSettingsに登録する方法

- 1を採用した理由
  - #defineによって、例えばDEBUGなのかRELEASEなのかを切り替えたい
  - その場合、ビルド時に外部からその定義だけを変更できたら便利そうだから
- 1のデメリット
  - rspファイルではコメントアウトができないらしい